### PR TITLE
fix rgba syntax

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -47,7 +47,7 @@ section {
   border-radius: 3px;
   font-family: 'Source Sans Pro', sans-serif;
   font-size: 10pt;
-  text-shadow: rgba(255,255,2550.5) 0 1px 2px;
+  text-shadow: rgba(255,255,255,0.5) 0 1px 2px;
   text-decoration: none;
   outline: none;
 }


### PR DESCRIPTION
Noticed there was a comma missing from an rgba value.